### PR TITLE
Re-enable lint-staged in pre-commit hook

### DIFF
--- a/.husky/pre-commit
+++ b/.husky/pre-commit
@@ -1,5 +1,4 @@
 #!/usr/bin/env sh
-# Temporarily disabled pre-commit hook to allow linting setup commit
-# Re-enable by uncommenting the line below:
-# npx lint-staged
-echo "Pre-commit hook temporarily disabled"
+. "$(dirname -- "$0")/_/husky.sh"
+
+npx lint-staged

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
-import { Suspense, lazy, useEffect } from 'react';
 import { CssBaseline, Box, Fade } from '@mui/material';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
+import { Suspense, lazy, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import '@fontsource/inter/300.css';
 import '@fontsource/inter/400.css';

--- a/src/App.js
+++ b/src/App.js
@@ -1,6 +1,6 @@
+import { Suspense, lazy, useEffect } from 'react';
 import { CssBaseline, Box, Fade } from '@mui/material';
 import { ThemeProvider as MuiThemeProvider } from '@mui/material/styles';
-import { Suspense, lazy, useEffect } from 'react';
 import { BrowserRouter as Router, Routes, Route } from 'react-router-dom';
 import '@fontsource/inter/300.css';
 import '@fontsource/inter/400.css';


### PR DESCRIPTION
This pull request re-enables the pre-commit linting hook and makes a minor import order adjustment in `src/App.js`. The most significant change is the restoration of lint checks before commits, which helps maintain code quality.

**Pre-commit hook:**
* Re-enabled the pre-commit hook in `.husky/pre-commit` to run `lint-staged` before each commit, ensuring code is linted automatically.

**Code style:**
* Adjusted the import order in `src/App.js` for consistency and clarity.